### PR TITLE
Header Mutation Functionality

### DIFF
--- a/src/burp/HeaderMutator.java
+++ b/src/burp/HeaderMutator.java
@@ -1,0 +1,286 @@
+package burp;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class HeaderMutator {
+    public ArrayList<String> mutations;
+
+    HeaderMutator() {
+        this.mutations = new ArrayList<String>();
+
+        this.registerMutation("nospace");
+        this.registerMutation("underscore");
+        this.registerMutation("cr-hyphen");
+        this.registerMutation("letter-hyphen");
+
+        this.registerMutation("linePrefixSpace");
+        this.registerMutation("linePrefixTab");
+        this.registerMutation("linePrefixVTab");
+        this.registerMutation("linePrefixNull");
+
+        this.registerMutation("lineAppendixNull");
+
+        this.registerMutation("colonPreNull");
+        this.registerMutation("colonPreSpace");
+        this.registerMutation("colonPreTab");
+        this.registerMutation("colonPreVTab");
+        this.registerMutation("colonPreCR");
+        this.registerMutation("colonPreLF");
+        this.registerMutation("colonPreJunk");
+
+        this.registerMutation("colonPostNull");
+        this.registerMutation("colonPostSpace");
+        this.registerMutation("colonPostTab");
+        this.registerMutation("colonPostVTab");
+        this.registerMutation("colonPostCR");
+        this.registerMutation("colonPostLF");
+        this.registerMutation("colonPostJunk");
+
+        this.registerMutation("singleQuote");
+        this.registerMutation("doubleQuote");
+
+        this.registerMutation("upperCase");
+        this.registerMutation("lowerCase");
+        this.registerMutation("mixedCase");
+
+        this.registerMutation("headerStartLF");
+        this.registerMutation("headerStartDoubleLF");
+        this.registerMutation("headerStartCR");
+        this.registerMutation("headerStartDoubleCR");
+        this.registerMutation("headerEndLF");
+        this.registerMutation("headerEndDoubleLF");
+        this.registerMutation("headerEndCR");
+        this.registerMutation("headerEndDoubleCR");
+    }
+
+    private void registerMutation(String name) {
+        this.mutations.add(name);
+    }
+
+    public byte[] mutate(String header, String mutation) {
+        String retStr = null;
+        byte[] ret = null;
+        switch (mutation) {
+            case "nospace":
+                retStr = header.replaceFirst(": ", ":");
+                break;
+
+            case "underscore":
+                retStr = header.replaceFirst("-", "_");
+                break;
+
+            case "cr-hyphen":
+                retStr = header.replaceFirst("-", "\r");
+                break;
+
+            case "letter-hyphen":
+                retStr = header.replaceFirst("-", "s");
+                break;
+
+            case "linePrefixSpace":
+                retStr = " " + header;
+                break;
+
+            case "linePrefixTab":
+                retStr = "\t" + header;
+                break;
+
+            case "linePrefixVTab":
+                retStr = new String(new byte[]{(byte)0x0b}) + header;
+                break;
+
+            case "linePrefixNull":
+                retStr = new String(new byte[]{(byte)0x00}) + header;
+                break;
+
+            case "lineAppendixNull":
+                retStr = header + new String(new byte[]{(byte)0x00});
+                break;
+
+            case "colonPreNull":
+                retStr = header.replaceFirst(":", "\0:");
+                break;
+
+            case "colonPreSpace":
+                retStr = header.replaceFirst(":", " :");
+                break;
+
+            case "colonPreTab":
+                retStr = header.replaceFirst(":", "\t:");
+                break;
+
+            case "colonPreVTab":
+                retStr = header.replaceFirst(":", new String(new byte[]{0x0b}) + ":");
+                break;
+
+            case "colonPreCR":
+                retStr = header.replaceFirst(":", "\r:");
+                break;
+
+            case "colonPreLF":
+                retStr = header.replaceFirst(":", "\n:");
+                break;
+
+            case "colonPreJunk":
+                retStr = header.replaceFirst(":", " abcd:");
+                break;
+
+            case "colonPostNull":
+                retStr = header.replaceFirst(":", ":\0");
+                break;
+
+            case "colonPostSpace":
+                retStr = header.replaceFirst(":", ": ");
+                break;
+
+            case "colonPostTab":
+                retStr = header.replaceFirst(":", ":\t");
+                break;
+
+            case "colonPostVTab":
+                retStr = header.replaceFirst(":", ":" + new String(new byte[]{0x0b}));
+                break;
+
+            case "colonPostCR":
+                retStr = header.replaceFirst(":", ":\r");
+                break;
+
+            case "colonPostLF":
+                retStr = header.replaceFirst(":", ":\n");
+                break;
+
+            case "colonPostJunk":
+                retStr = header.replaceFirst(":", ":abcd ");
+                break;
+
+            case "singleQuote":
+                retStr = header.replaceFirst(":\\s*", ": '").replaceFirst("$", "'");
+                break;
+
+            case "doubleQuote":
+                retStr = header.replaceFirst(":\\s*", ": \"").replaceFirst("$", "\"");
+                break;
+
+            case "upperCase":
+                retStr = header.toUpperCase();
+                break;
+
+            case "lowerCase":
+                retStr = header.toLowerCase();
+                break;
+
+            case "mixedCase":
+                retStr = "";
+                for (int i = 0; i < header.length(); i++) {
+                    char c;
+                    if (i%2 == 0) {
+                        c = Character.toLowerCase(header.charAt(i));
+                    } else {
+                        c = Character.toUpperCase(header.charAt(i));
+                    }
+                    retStr = retStr + c;
+                }
+                break;
+
+            case "headerStartLF":
+                retStr = "Foo: Bar\n" + header;
+                break;
+
+            case "headerStartDoubleLF":
+                retStr = "Foo: Bar\n\n" + header;
+                break;
+
+            case "headerStartCR":
+                retStr = "Foo: Bar\r" + header;
+                break;
+
+            case "headerStartDoubleCR":
+                retStr = "Foo: Bar\r\r" + header;
+                break;
+
+            case "headerEndLF":
+                retStr = header + "\nFoo: Bar";
+                break;
+
+            case "headerEndDoubleLF":
+                retStr = header + "\n\nFoo: Bar";
+                break;
+
+            case "headerEndCR":
+                retStr = header + "\rFoo: Bar";
+                break;
+
+            case "headerEndDoubleCR":
+                retStr = header + "\r\rFoo: Bar";
+                break;
+
+            default:
+                Utilities.out("Unknown mutation " + mutation + " requested!");
+                retStr = header;
+                break;
+        }
+
+        if (ret == null && retStr != null) {
+            return retStr.getBytes(StandardCharsets.UTF_8);
+        }
+        return ret;
+    }
+
+    public byte[] mutateRequest(byte[] req, String mutation, String[] headers) throws IOException {
+        ByteArrayOutputStream ret = new ByteArrayOutputStream();
+
+        // Get sorted header offsets, and a sorted array of their indices, sorted by the start offset of the header
+        ArrayList<int[]> offsets = new ArrayList<int[]>();
+        for (int i = 0; i < headers.length; i++) {
+            String header = headers[i];
+            if (header.contains("~")) {
+                header = header.split("~", 2)[0];
+            }
+            int[] offs = Utilities.getHeaderOffsets(req, header);
+            if (offs !=  null) {
+                offsets.add(offs);
+            }
+        }
+
+        offsets.sort(new java.util.Comparator<int[]>(){
+            public int compare(int[] a, int[] b) {
+                return Integer.compare(a[0], b[0]);
+            }
+        });
+        // Copy over req to ret, replacing headers as we go
+        int offset = 0;
+        Iterator<int[]> iterator = offsets.iterator();
+        while (iterator.hasNext()) {
+            int[] markers = iterator.next();
+            int headerStart = markers[0];
+            int headerEnd = markers[2];
+
+            // Copy up to the start of the header
+
+            // Duplicate headers cause an issue here. However, switching offset and headerStart seems to just fix it.
+            if (offset >= headerStart) {
+                int tmp = offset;
+                offset = headerStart;
+                headerStart = tmp;
+            }
+            ret.write(Arrays.copyOfRange(req, offset, headerStart));
+            offset = headerEnd;
+
+            // Copy in mutated header
+            byte[] headerBytes = Arrays.copyOfRange(req, headerStart, headerEnd);
+            String headerStr = new String(headerBytes, StandardCharsets.UTF_8);
+            byte[] newHeader = this.mutate(headerStr, mutation);
+            ret.write(newHeader);
+        }
+
+        // Copy in rest of request
+        ret.write(Arrays.copyOfRange(req, offset, req.length));
+
+        return ret.toByteArray();
+    }
+}

--- a/src/burp/PayloadInjector.java
+++ b/src/burp/PayloadInjector.java
@@ -1,5 +1,6 @@
 package burp;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 
@@ -29,20 +30,24 @@ class PayloadInjector {
         this.insertionPoint = insertionPoint;
     }
 
-    // fixme horribly inefficient
     ArrayList<Attack> fuzz(Attack baselineAttack, Probe probe) {
+        return fuzz(baselineAttack, probe, null);
+    }
+
+    // fixme horribly inefficient
+    ArrayList<Attack> fuzz(Attack baselineAttack, Probe probe, String mutation) {
         ArrayList<Attack> attacks = new ArrayList<>(2);
-        Attack breakAttack = buildAttackFromProbe(probe, probe.getNextBreak());
+        Attack breakAttack = buildAttackFromProbe(probe, probe.getNextBreak(), mutation);
 
         if (Utilities.identical(baselineAttack, breakAttack)) {
             return new ArrayList<>();
         }
 
         for(int k=0; k<probe.getNextEscapeSet().length; k++) {
-            Attack doNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[k]);
+            Attack doNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[k], mutation);
             doNotBreakAttack.addAttack(baselineAttack);
             if(!Utilities.identical(doNotBreakAttack, breakAttack)) {
-                attacks = verify(doNotBreakAttack, breakAttack, probe, k);
+                attacks = verify(doNotBreakAttack, breakAttack, probe, k, mutation);
                 if (!attacks.isEmpty()) {
                     break;
                 }
@@ -53,6 +58,10 @@ class PayloadInjector {
     }
 
     private ArrayList<Attack> verify(Attack doNotBreakAttackSeed, Attack breakAttackSeed, Probe probe, int chosen_escape) {
+        return verify(doNotBreakAttackSeed, breakAttackSeed, probe, chosen_escape, null);
+    }
+
+    private ArrayList<Attack> verify(Attack doNotBreakAttackSeed, Attack breakAttackSeed, Probe probe, int chosen_escape, String mutation) {
         ArrayList<Attack> attacks = new ArrayList<>(2);
         Attack mergedBreakAttack = new Attack();
         mergedBreakAttack.addAttack(breakAttackSeed);
@@ -62,7 +71,7 @@ class PayloadInjector {
         Attack tempDoNotBreakAttack = doNotBreakAttackSeed;
 
         for(int i=0; i<Utilities.CONFIRMATIONS; i++) {
-            Attack tempBreakAttack = buildAttackFromProbe(probe, probe.getNextBreak());
+            Attack tempBreakAttack = buildAttackFromProbe(probe, probe.getNextBreak(), mutation);
             mergedBreakAttack.addAttack(tempBreakAttack);
 
             if(Utilities.similarIsh(mergedDoNotBreakAttack, mergedBreakAttack, tempDoNotBreakAttack, tempBreakAttack)
@@ -70,7 +79,7 @@ class PayloadInjector {
                 return new ArrayList<>();
             }
 
-            tempDoNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[chosen_escape]);
+            tempDoNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[chosen_escape], mutation);
             mergedDoNotBreakAttack.addAttack(tempDoNotBreakAttack);
 
             if(Utilities.similarIsh(mergedDoNotBreakAttack, mergedBreakAttack, tempDoNotBreakAttack, tempBreakAttack)
@@ -81,9 +90,9 @@ class PayloadInjector {
         }
 
         // this final probe pair is sent out of order, to prevent alternation false positives
-        tempDoNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[chosen_escape]);
+        tempDoNotBreakAttack = buildAttackFromProbe(probe, probe.getNextEscapeSet()[chosen_escape], mutation);
         mergedDoNotBreakAttack.addAttack(tempDoNotBreakAttack);
-        Attack tempBreakAttack = buildAttackFromProbe(probe, probe.getNextBreak());
+        Attack tempBreakAttack = buildAttackFromProbe(probe, probe.getNextBreak(), mutation);
         mergedBreakAttack.addAttack(tempBreakAttack);
 
         // point is to exploit response attributes that vary in "don't break" responses (but are static in 'break' responses)
@@ -100,6 +109,10 @@ class PayloadInjector {
 
 
     private Attack buildAttackFromProbe(Probe probe, String payload) {
+        return buildAttackFromProbe(probe, payload, null);
+    }
+
+    private Attack buildAttackFromProbe(Probe probe, String payload, String mutation) {
         boolean randomAnchor = probe.getRandomAnchor();
         byte prefix = probe.getPrefix();
 
@@ -126,7 +139,7 @@ class PayloadInjector {
         }
 
 
-        IHttpRequestResponse req = buildRequest(payload, probe.useCacheBuster());
+        IHttpRequestResponse req = buildRequest(payload, probe.useCacheBuster(), mutation);
         if(randomAnchor) {
             req = Utilities.highlightRequestResponse(req, anchor, anchor, insertionPoint);
         }
@@ -135,11 +148,25 @@ class PayloadInjector {
     }
 
     IHttpRequestResponse buildRequest(String payload, boolean needCacheBuster) {
+        return buildRequest(payload, needCacheBuster, null);
+    }
+
+    IHttpRequestResponse buildRequest(String payload, boolean needCacheBuster, String mutation) {
 
         byte[] request = insertionPoint.buildRequest(payload.getBytes());
 
         if (needCacheBuster) {
             request = Utilities.addCacheBuster(request, Utilities.generateCanary());
+        }
+
+        if (mutation != null) {
+            HeaderMutator mutator = new HeaderMutator();
+            try {
+                byte[] newRequest = mutator.mutateRequest(request, mutation, payload.split("\\|"));
+                request = newRequest;
+            } catch (IOException e) {
+                Utilities.out(e.toString());
+            }
         }
 
         IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request);
@@ -149,12 +176,26 @@ class PayloadInjector {
     }
 
     Attack probeAttack(String payload) {
+        return probeAttack(payload, null);
+    }
+
+    Attack probeAttack(String payload, String mutation) {
         byte[] request = insertionPoint.buildRequest(payload.getBytes());
 
         //IParameter cacheBuster = burp.Utilities.helpers.buildParameter(Utilities.generateCanary(), "1", IParameter.PARAM_URL);
         //request = burp.Utilities.helpers.addParameter(request, cacheBuster);
         //request = burp.Utilities.appendToQuery(request, Utilities.generateCanary()+"=1");
         request = Utilities.addCacheBuster(request, Utilities.generateCanary());
+
+        if (mutation != null) {
+            HeaderMutator mutator = new HeaderMutator();
+            try {
+                byte[] newRequest = mutator.mutateRequest(request, mutation, payload.split("\\|"));
+                request = newRequest;
+            } catch (java.io.IOException e) {
+                //Utilities.out("ERROR: failed to mutate request: " + e.toString());
+            }
+        }
 
         IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request);
         return new Attack(requestResponse, null, null, "");


### PR DESCRIPTION
Changes along with param-miner PR to detect header smuggling. Added:

Created new class `HeaderMutator` to mutate headers.

Modified `PayloadInjector.java` to add a "mutation" parameter to most methods. This is used to mutate headers using a `HeaderMutator` where necessary.