### PR TITLE
Force HTTP/1.1 when using a mutation

### DIFF
--- a/src/burp/PayloadInjector.java
+++ b/src/burp/PayloadInjector.java
@@ -159,7 +159,9 @@ class PayloadInjector {
             request = Utilities.addCacheBuster(request, Utilities.generateCanary());
         }
 
+        boolean forceHttp1 = false;
         if (mutation != null) {
+            forceHttp1 = true;
             HeaderMutator mutator = new HeaderMutator();
             try {
                 byte[] newRequest = mutator.mutateRequest(request, mutation, payload.split("\\|"));
@@ -169,7 +171,7 @@ class PayloadInjector {
             }
         }
 
-        IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request);
+        IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request, forceHttp1);
         //Utilities.out("Payload: "+payload+"|"+baseRequestResponse.getHttpService().getHost());
 
         return requestResponse;// Utilities.buildRequest(baseRequestResponse, insertionPoint, payload)
@@ -187,7 +189,9 @@ class PayloadInjector {
         //request = burp.Utilities.appendToQuery(request, Utilities.generateCanary()+"=1");
         request = Utilities.addCacheBuster(request, Utilities.generateCanary());
 
+        boolean forceHttp1 = false;
         if (mutation != null) {
+            forceHttp1 = true;
             HeaderMutator mutator = new HeaderMutator();
             try {
                 byte[] newRequest = mutator.mutateRequest(request, mutation, payload.split("\\|"));
@@ -197,7 +201,7 @@ class PayloadInjector {
             }
         }
 
-        IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request);
+        IHttpRequestResponse requestResponse = burp.Utilities.attemptRequest(service, request, forceHttp1);
         return new Attack(requestResponse, null, null, "");
     }
 

--- a/src/burp/Utilities.java
+++ b/src/burp/Utilities.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.List;
@@ -1200,7 +1201,18 @@ class Utilities {
         }
     }
 
+    static byte[] convertToHttp1(byte[] req) {
+        // ISO-8859-1 has a 1-to-1 encoding between strings and bytes
+        String tmp = new String(req, StandardCharsets.ISO_8859_1);
+        tmp = tmp.replaceFirst("HTTP/2", "HTTP/1.1");
+        return tmp.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
     static IHttpRequestResponse attemptRequest(IHttpService service, byte[] req) {
+        return attemptRequest(service, req, false);
+    }
+
+    static IHttpRequestResponse attemptRequest(IHttpService service, byte[] req, boolean forceHttp1) {
         if(unloaded.get()) {
             Utilities.out("Extension unloaded - aborting attack");
             throw new RuntimeException("Extension unloaded");
@@ -1229,7 +1241,7 @@ class Utilities {
                     result = fetchWithGo(service, req);
                 }
                 else {
-                    result = callbacks.makeHttpRequest(service, req);
+                    result = callbacks.makeHttpRequest(service, req, forceHttp1);
                 }
 
             } catch(RuntimeException e) {


### PR DESCRIPTION
When a header mutation is passed to a request-generating method, force the request to be send over HTTP/1.1. Also adds a method to convert raw request bodies to HTTP/1.1 by changing "HTTP/2" to "HTTP/1.1".

See https://github.com/PortSwigger/param-miner/pull/70